### PR TITLE
added team analytics table

### DIFF
--- a/app/analytics.py
+++ b/app/analytics.py
@@ -12,7 +12,7 @@ from config import conn
 def getdb():
     return pd.read_sql_query(
     "SELECT workshop.id, workshop_name, workshop_category, workshop_instructor, \
-        workshop_start, workshop_hours, class_size, e.name \
+        workshop_start, workshop_hours, class_size, e.name, e.active, e.university \
         FROM workshop \
         LEFT JOIN employee as e ON e.id = workshop.workshop_instructor",
         conn, index_col='id')
@@ -336,6 +336,75 @@ def instructor_breakdown():
     return chart.to_json()
 
 # ================ ================ ================
+# ================ Team Analytics Section ================
+#
+# Visualization relating to team analytics page
+#
+# ===================================================
+# ===================================================
+@app.route('/data/team_leadinst_line')
+def team_leadinst_line():
+    dat = df.copy()
+    sixmonths = datetime.datetime.now() - datetime.timedelta(weeks=26)
+    threemonths = datetime.datetime.now() - datetime.timedelta(weeks=13)
+    dat = dat.loc[(dat.workshop_start >= sixmonths) &
+            (dat.active == 1) & (dat.name != 'Capstone'), :]
+    dat['workshop_period'] = dat.loc[:, 'workshop_start'].apply(lambda x: 'Last 3 months' if (x >= threemonths) else '3 months ago')
+    dat = dat.loc[:,['name','workshop_period','workshop_hours']].groupby(['name','workshop_period']).count().reset_index()
+    dat.columns = ['name', 'workshop_period', 'wh_count']
+    dat['diff'] = dat.groupby('name').diff().fillna(method='bfill', limit=1)
+
+    line = alt.Chart(data=dat, title='Lead Instructor Roles').mark_line().encode(
+        x=alt.X('wh_count', axis=alt.Axis(title='Workshops in the last 6 months')),
+        y=alt.Y('name', axis=alt.Axis(title=' ')),
+        detail='name',
+        color=alt.condition(
+            alt.datum.diff > 0,
+            alt.value("black"),
+            alt.value("#fd7777")
+        )
+    )
+
+    p1 = alt.Chart(data=dat).mark_point(filled=True, size=100).encode(
+        x='wh_count',
+        y='name',
+        color=alt.Color('workshop_period:O', 
+                        scale=alt.Scale(range=['#375d7b','black']),
+                        legend=alt.Legend(orient='bottom-right', 
+                                        title=None,
+                                        offset=4, 
+                                        zindex=0)
+                    ),
+        tooltip=['workshop_period:O', 'wh_count']
+    )
+
+    t1 = p1.mark_text(
+        align='right',
+        baseline='bottom',
+        dx=-3, dy=-1,
+    ).encode(
+        text='wh_count',
+        color=alt.condition(
+            alt.datum.diff > 0,
+            alt.value("black"),
+            alt.value("#fd7777")
+        )
+    ).transform_filter(
+        filter={"field":'workshop_period',
+            "oneOf": ['Last 3 months']}
+    )
+
+    rule = alt.Chart(dat).mark_rule(color='#bbc6cb', strokeDash=[4]).encode(
+        x='average(wh_count)',
+        size=alt.value(1)
+    )
+
+    chart = line + p1 + t1 + rule
+    chart = chart.configure_axis(grid=False).properties(width=580)
+
+    return chart.to_json()
+
+# ================ ================ ================
 # ================ Non-Chart Section ================
 #
 #  Each factory is responsible for the data required 
@@ -364,6 +433,38 @@ def factory_homepage():
                 .to_html(classes=['table thead-light table-striped table-bordered table-hover table-sm'])
     }
     return stats
+
+def factory_analytics():
+    dat = df.copy()
+    sixmonths = datetime.datetime.now() - datetime.timedelta(weeks=26)
+    threemonths = datetime.datetime.now() - datetime.timedelta(weeks=13)
+    dat = dat.loc[(dat.workshop_start >= sixmonths) &
+            (dat.active == 1) & (dat.name != 'Capstone'), :]
+    dat['workshop_period'] = dat.loc[:, 'workshop_start'].apply(lambda x: 'Last 3 months' if (x >= threemonths) else '3 months ago')
+    dat = dat.loc[:,['name','workshop_period','workshop_hours']].groupby(['name','workshop_period']).count().reset_index()
+    dat.columns = ['name', 'workshop_period', 'wh_count']
+    dat['diff'] = dat.groupby('name').diff().fillna(method='bfill', limit=1)
+    df_sum = pd.DataFrame(dat.groupby('name').wh_count.sum())
+    max_wh = df_sum.wh_count.max()
+    min_wh = df_sum.wh_count.min()
+    max_diff = dat['diff'].max()
+    min_diff = dat['diff'].min()
+    def gettimenow():
+        import arrow
+        return arrow.get(arrow.utcnow()).humanize()
+    instructorstats = {
+        'max_wh': max_wh,
+        'min_wh': min_wh,
+        'max_6mths': [i for i in df_sum[df_sum.wh_count == max_wh].index],
+        'min_6mths': [i for i in df_sum[df_sum.wh_count == min_wh].index],
+        'max_diff_n': max_diff,
+        'min_diff_n': min_diff,
+        'max_diff': [i for i in dat[dat['diff']==max_diff].name.unique()],
+        'min_diff': [i for i in dat[dat['diff']==min_diff].name.unique()],
+        'testing': ['John Doe', 'Max Brenner'],
+        'updatewhen': gettimenow(),
+    }
+    return instructorstats
 
 
 def factory_accomplishment(u):

--- a/app/analytics.py
+++ b/app/analytics.py
@@ -166,7 +166,6 @@ def category_bars():
 # ===================================================
 
 @app.route('/data/person_contrib_area')
-@cache.cached(timeout=86400, key_prefix='p_contrb')
 def person_contrib_area():
     dat_ori = getuserdb()
     dat = dat_ori.loc[dat_ori.this_user == True,:].copy()
@@ -195,7 +194,6 @@ def person_contrib_area():
     return chart.to_json()
 
 @app.route('/data/person_class_bar')
-@cache.cached(timeout=86400, key_prefix='p_hours')
 def person_class_bar():
     dat_ori = getuserdb()
     dat = dat_ori.loc[dat_ori.this_user == True,:].copy()
@@ -220,7 +218,6 @@ def person_class_bar():
     return chart.to_json()
 
 @app.route('/data/person_vs_area')
-@cache.cached(timeout=86400, key_prefix='p_v_a')
 def person_vs_area():
     dat_ori = getuserdb()
     dat = dat_ori.loc[dat_ori.this_user == True,:].copy()
@@ -254,7 +251,7 @@ def person_vs_area():
 
 
 @app.route('/data/instructor_breakdown')
-@cache.cached(timeout=86400, key_prefix='ib')
+@cache.cached(timeout=86400*7, key_prefix='ib')
 def instructor_breakdown():
     # Getting Responses Data
     q = """ SELECT response.*, workshop_category, name
@@ -461,7 +458,7 @@ def factory_analytics():
         'min_diff_n': min_diff,
         'max_diff': [i for i in dat[dat['diff']==max_diff].name.unique()],
         'min_diff': [i for i in dat[dat['diff']==min_diff].name.unique()],
-        'testing': ['John Doe', 'Max Brenner'],
+        'testing': ['Steven Surya', 'Steven Christian'],
         'updatewhen': gettimenow(),
     }
     return instructorstats

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,7 +1,7 @@
 from flask import render_template, flash, redirect, url_for, g
 from flask_login import current_user, login_user, logout_user, login_required
 from app import app, db, cache
-from app.analytics import factory_homepage, factory_accomplishment
+from app.analytics import factory_homepage, factory_accomplishment, factory_analytics
 from app.users import User
 from app.models import Employee, Workshop, Response
 from app.forms import LoginForm, RegistrationForm, SurveyForm, ResetPasswordRequestForm, ResetPasswordForm
@@ -20,7 +20,7 @@ def before_request():
 @app.route('/index')
 @cache.cached(timeout=100)
 def index():
-    stats=factory_homepage()
+    stats = factory_homepage()
     return render_template('index.html', stats=stats)
 
 @app.route('/accomplishment')
@@ -30,7 +30,7 @@ def accomplishment():
     if g.employee is None:
         flash('Not registered as a Product team member yet. Check back later!')
         return redirect(url_for('index'))
-    personstats=factory_accomplishment(u=g.employee)
+    personstats = factory_accomplishment(u=g.employee)
     return render_template('accomplishment.html', personstats=personstats)
 
 @app.route('/explorer')
@@ -41,7 +41,8 @@ def explorer():
 
 @app.route('/analytics')
 def analytics():
-    return render_template('analytics.html')
+    instructorstats = factory_analytics()
+    return render_template('analytics.html', instructorstats=instructorstats)
 
 @app.route('/login', methods=['GET', 'POST'])
 def login():

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,6 +1,6 @@
 from flask import render_template, flash, redirect, url_for, g
 from flask_login import current_user, login_user, logout_user, login_required
-from app import app, db, cache
+from app import app, db
 from app.analytics import factory_homepage, factory_accomplishment, factory_analytics
 from app.users import User
 from app.models import Employee, Workshop, Response
@@ -18,7 +18,6 @@ def before_request():
 
 @app.route('/')
 @app.route('/index')
-@cache.cached(timeout=100)
 def index():
     stats = factory_homepage()
     return render_template('index.html', stats=stats)
@@ -35,7 +34,6 @@ def accomplishment():
 
 @app.route('/explorer')
 @login_required
-@cache.cached(timeout=86400*7)
 def explorer():
     return render_template('explorer.html')
 

--- a/app/static/css/pedagogy.css
+++ b/app/static/css/pedagogy.css
@@ -54,6 +54,15 @@ i.material-icons.md-light {
     color: black
 }
 
+.instructor {
+    padding: 2% 4%;
+    display: block;
+    margin: 1.5%;
+    border-radius: 5px;
+    font-weight: bolder;
+    color: white;
+}
+
 .statcards-header{
     font-size:0.7em;
     color: white;

--- a/app/static/css/pedagogy.css
+++ b/app/static/css/pedagogy.css
@@ -28,12 +28,30 @@ i.material-icons.md-light {
     background-color: rgb(124, 152, 174);
 }
 
+.jumbotron.white {
+    background-color: rgba(255,255,255,1);
+    padding: 2rem 2rem 4rem;
+    margin: 1.6rem;
+}
+
+.jumbotron.white > h2 {
+    color:#375d7b
+}
+
 .statcards {
     margin: 1% 0;
     background-color: rgb(124, 152, 174);
     padding: 2.5% 1.5%;
     border-radius: 5px;
     color: white;
+}
+
+.leadinst_table {
+    font-size: 0.8em
+}
+
+.leadinst_table tr{
+    color: black
 }
 
 .statcards-header{
@@ -167,6 +185,10 @@ body{
 
 h2, h3, h4 {
     color: white;
+}
+
+h5 {
+    text-align: left;
 }
 
 tr {

--- a/app/templates/analytics.html
+++ b/app/templates/analytics.html
@@ -23,34 +23,34 @@
                             <th scope="row">Most Prolific</th>
                             <td>
                                 {% for inst in instructorstats['max_6mths'] %}
-                                    {{ inst }}
+                                <span class="instructor btn-info">{{ inst }}</span>
                                 {% endfor %}
                             </td>
-                            <td>{{ instructorstats.max_wh }} workshops in the last 6 months</td>
+                            <td>{{ instructorstats.max_wh }} workshop(s) in the last 6 months</td>
                         </tr>
                         <tr>
                             <th scope="row">Training Camp</th>
                             <td>
                                 {% for inst in instructorstats['min_6mths'] %}
-                                    {{ inst }}
+                                <span class="instructor btn-secondary">{{ inst }}</span>
                                 {% endfor %}
                             </td>
-                            <td>{{ instructorstats.min_wh }} workshops in the last 6 months</td>
+                            <td>{{ instructorstats.min_wh }} workshop(s) in the last 6 months</td>
                         </tr>
                         <tr>
                             <th scope="row">Steepest Ascent</th>
                             <td>
                                 {% for inst in instructorstats['max_diff'] %}
-                                    {{ inst }}
+                                <span class="instructor btn-success">{{ inst }}</span>
                                 {% endfor %}
                             </td>
                             <td>{{ instructorstats.max_diff_n }} difference compared to previous period</td>
                         </tr>    
                         <tr>
-                            <th scope="row">Training Camp</th>
+                            <th scope="row">Steepest Descent</th>
                             <td>
                                 {% for inst in instructorstats['min_diff'] %}
-                                    {{ inst }}
+                                <span class="instructor btn-danger">{{ inst }}</span>
                                 {% endfor %}
                             </td>
                             <td>{{ instructorstats.min_diff_n }} difference compared to previous period</td>
@@ -59,14 +59,20 @@
                             <th scope="row">Testing Multiple</th>
                             <td>
                                 {% for inst in instructorstats['testing'] %}
-                                    {{ inst }}
+                                    <span class="instructor btn-warning">{{ inst }}</span>
                                 {% endfor %}
                             </td>
-                            <td>{{ instructorstats.min_diff_n }} difference compared to previous period</td>
+                            <td>Purely for testing front-end code.</td>
                         </tr>
                         <tr>
-                            <th scope="row">Summary</th>
-                            <td colspan="2">Larry the Bird</td>
+                            <th scope="row">Recommendations</th>
+                            <td colspan="2">
+                                    {% for inst in instructorstats['min_diff'] %}
+                                    {{ inst }} 
+                                    {% endfor %}
+                                    has had limited leading roles in the last 3 months. 
+                                    Consider more responbsibilities for the individual or call for a performance evaluation. 
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/app/templates/analytics.html
+++ b/app/templates/analytics.html
@@ -4,12 +4,73 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-lite/2.6.0/vega-lite.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/vega-embed/3.20.0/vega-embed.min.js"></script>
 
-    <div class="jumbotron lightaqua">
-        <h2><i class="material-icons md-light">insert_chart</i> Team Analytics </h2>
+    <div class="jumbotron white">
+        <h2><i class="material-icons md-dark">insert_chart</i> Team Analytics </h2>
         <div class="row">
-            <div class="col-md-6 col-lg-6 col-sm-6" id="vis_team_1">
-            
-            </div>
+            <div class="col-md-12 col-lg-7 col-sm-12" id="vis_team_1"></div>
+            <div class="col-md-12 col-lg-5 col-sm-12">
+                <table class="table table-bordered leadinst_table">
+                    <caption>Last updated {{ instructorstats.updatewhen }}</caption>
+                    <thead class="thead-light">
+                      <tr>
+                        <th scope="col">Title</th>
+                        <th scope="col">Individual</th>
+                        <th scope="col">Remark</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <th scope="row">Most Prolific</th>
+                            <td>
+                                {% for inst in instructorstats['max_6mths'] %}
+                                    {{ inst }}
+                                {% endfor %}
+                            </td>
+                            <td>{{ instructorstats.max_wh }} workshops in the last 6 months</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Training Camp</th>
+                            <td>
+                                {% for inst in instructorstats['min_6mths'] %}
+                                    {{ inst }}
+                                {% endfor %}
+                            </td>
+                            <td>{{ instructorstats.min_wh }} workshops in the last 6 months</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Steepest Ascent</th>
+                            <td>
+                                {% for inst in instructorstats['max_diff'] %}
+                                    {{ inst }}
+                                {% endfor %}
+                            </td>
+                            <td>{{ instructorstats.max_diff_n }} difference compared to previous period</td>
+                        </tr>    
+                        <tr>
+                            <th scope="row">Training Camp</th>
+                            <td>
+                                {% for inst in instructorstats['min_diff'] %}
+                                    {{ inst }}
+                                {% endfor %}
+                            </td>
+                            <td>{{ instructorstats.min_diff_n }} difference compared to previous period</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Testing Multiple</th>
+                            <td>
+                                {% for inst in instructorstats['testing'] %}
+                                    {{ inst }}
+                                {% endfor %}
+                            </td>
+                            <td>{{ instructorstats.min_diff_n }} difference compared to previous period</td>
+                        </tr>
+                        <tr>
+                            <th scope="row">Summary</th>
+                            <td colspan="2">Larry the Bird</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>          
         </div>
     </div>
 
@@ -26,9 +87,7 @@
               // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
             }).catch(console.error);
         }
-        // parse("/data/mediumos", "#vis1")
-        // parse("/data/studentprof", "#vis2")
-        parse("/data/person_class_bar", "#vis_team_1")
+        parse("/data/team_leadinst_line", "#vis_team_1")
     </script>
 {% endblock %}
 


### PR DESCRIPTION
Veteran updates 1
- Fleshed out team analytics page. 
- Included table to summarise information in the visualization on the left
- Use Arrow to show last fetched time in human friendly format (_7 minutes ago_, _1 hour ago_ etc)
- TODO: Accept possibilities of multiple winners in each category

<img width="1401" alt="Screenshot 2019-04-22 at 10 36 57 PM" src="https://user-images.githubusercontent.com/16984453/56505789-33f49700-654f-11e9-933f-fb7c7e61f33e.png">